### PR TITLE
Improve crawler usability

### DIFF
--- a/EinstellungenApp/MainWindow.xaml
+++ b/EinstellungenApp/MainWindow.xaml
@@ -37,11 +37,13 @@
                     <StackPanel Margin="10" x:Name="CrawlerPanel">
                         <StackPanel Orientation="Horizontal" Margin="0,2">
                             <TextBlock Text="Domain CSV:" Width="100"/>
-                            <TextBox x:Name="DomainCsvPath" Width="350"/>
+                            <TextBox x:Name="DomainCsvPath" Width="300"/>
+                            <Button Content="Browse..." Margin="5,0,0,0" Click="OnBrowseDomainCsv" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,2">
                             <TextBlock Text="Proxy CSV:" Width="100"/>
-                            <TextBox x:Name="ProxyCsvPath" Width="350"/>
+                            <TextBox x:Name="ProxyCsvPath" Width="300"/>
+                            <Button Content="Browse..." Margin="5,0,0,0" Click="OnBrowseProxyCsv" />
                         </StackPanel>
                         <StackPanel Orientation="Horizontal" Margin="0,2">
                             <TextBlock Text="Rounds:" Width="100"/>
@@ -59,7 +61,10 @@
                             <TextBlock Text="FlushInterval(s):" Width="100"/>
                             <TextBox x:Name="FlushIntervalInput" Width="50" Text="60"/>
                         </StackPanel>
-                        <Button Content="Start" Margin="0,5" Click="OnStartCrawler" Width="100"/>
+                        <StackPanel Orientation="Horizontal" Margin="0,5">
+                            <Button Content="Start" Click="OnStartCrawler" Width="100" Margin="0,0,5,0"/>
+                            <Button Content="Stop" Click="OnStopCrawler" Width="100"/>
+                        </StackPanel>
                         <TextBox x:Name="CrawlerLog" AcceptsReturn="True" IsReadOnly="True" VerticalScrollBarVisibility="Auto" Height="150" Margin="0,5,0,0"/>
                     </StackPanel>
                 </ScrollViewer>

--- a/EinstellungenApp/MainWindow.xaml.cs
+++ b/EinstellungenApp/MainWindow.xaml.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 using System.Threading;
 using System.Linq;
 using System.IO;
+using Microsoft.Win32;
 
 namespace EinstellungenApp
 {
@@ -19,6 +20,7 @@ namespace EinstellungenApp
         private long _lastBytesSent;
         private long _lastBytesReceived;
         private Crawler? _crawler;
+        private CancellationTokenSource? _cts;
 
         public MainWindow()
         {
@@ -104,6 +106,20 @@ namespace EinstellungenApp
             return $"{value:0.##} {units[unit]}";
         }
 
+        private void OnBrowseDomainCsv(object sender, RoutedEventArgs e)
+        {
+            var dlg = new OpenFileDialog { Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*" };
+            if (dlg.ShowDialog() == true)
+                DomainCsvPath.Text = dlg.FileName;
+        }
+
+        private void OnBrowseProxyCsv(object sender, RoutedEventArgs e)
+        {
+            var dlg = new OpenFileDialog { Filter = "CSV files (*.csv)|*.csv|All files (*.*)|*.*" };
+            if (dlg.ShowDialog() == true)
+                ProxyCsvPath.Text = dlg.FileName;
+        }
+
         private async void OnStartCrawler(object sender, RoutedEventArgs e)
         {
             CrawlerLog.Text = string.Empty;
@@ -123,8 +139,13 @@ namespace EinstellungenApp
                 CrawlerLog.AppendText(msg + System.Environment.NewLine);
                 CrawlerLog.ScrollToEnd();
             }));
+            _cts = new CancellationTokenSource();
+            await Task.Run(() => _crawler.RunAsync(opts, _cts.Token));
+        }
 
-            await Task.Run(() => _crawler.RunAsync(opts));
+        private void OnStopCrawler(object sender, RoutedEventArgs e)
+        {
+            _cts?.Cancel();
         }
     }
 }


### PR DESCRIPTION
## Summary
- add Browse buttons for selecting domain and proxy CSV files
- introduce Stop button for crawler cancellation
- track counts for found links and proxies
- update progress log to show discovered counts

## Testing
- `dotnet build EinstellungenApp/EinstellungenApp.csproj -c Release` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849525200ac8333b0b296c2646ac3c1